### PR TITLE
Add automatic test run

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+    pull_request:
+    push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.17' ]
+    name: Go ${{ matrix.go }} test
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - run: go test ./...


### PR DESCRIPTION
While opening #1 I noticed there is no automatic test run on this repo.

Here is a proposal to run tests automatically using a GitHub workflow (can be seen here: https://github.com/tucksaun/terminal/actions/workflows/test.yaml).

As this repo is to be considered as a library (opposed to a final binary), I used a matrix in order to be able to add new Go versions in the future. 